### PR TITLE
Feature/custom formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,17 +172,6 @@ This example treats a uint32 as a Unix timestamp (epoch seconds) and
 converts between the raw integer, hex, and an ISO 8601 UTC date:
 
 ```lua
-local function iso_to_epoch(text)
-  local y, mo, d, h, mi, s = text:match("(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+)")
-  if not y then return nil end
-  -- os.time uses local time; subtract the local UTC offset to get UTC epoch.
-  local utc_offset = os.time(os.date("!*t", 0))
-  return os.time({
-    year = tonumber(y), month = tonumber(mo), day = tonumber(d),
-    hour = tonumber(h), min = tonumber(mi), sec = tonumber(s), isdst = false,
-  }) - utc_offset
-end
-
 require("convy").setup({
   formats = {
     {
@@ -205,7 +194,15 @@ require("convy").setup({
           display = "ISO date",
           -- optional: makes `auto` recognise ISO dates
           detect = function(text) return text:match("^%d%d%d%d%-%d%d%-%d%dT") ~= nil end,
-          decode = iso_to_epoch,
+          decode = function(text)
+            local y, mo, d, h, mi, s = text:match("(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+)")
+            if not y then return nil end
+            local utc_offset = os.time(os.date("!*t", 0))
+            return os.time({
+              year = tonumber(y), month = tonumber(mo), day = tonumber(d),
+              hour = tonumber(h), min = tonumber(mi), sec = tonumber(s), isdst = false,
+            }) - utc_offset
+          end,
           encode = function(secs) return os.date("!%Y-%m-%dT%H:%M:%SZ", secs) end,
         },
       },

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A powerful Neovim plugin to convert between various formats
 - 🤖 Auto-detection of input format
 - 🎯 Smart selection: works with visual selection or word-under-cursor
 - 🌳 Interactive split-window tree UI with search and live result preview
+- 🧩 Custom formats: add your own units or conversions from your config
 
 ## 📦 Installation
 
@@ -48,6 +49,9 @@ A powerful Neovim plugin to convert between various formats
     window = {
       position = "left", -- "left" or "right"
       width = 36,
+    },
+    formats = {
+      -- custom formats, see section below
     },
   },
   keys = {
@@ -134,6 +138,82 @@ lua require("convy.utils").set_separator(", ") -- sets the separator to `, `
 " Select the input format (or `auto`) with `<CR>`/`<Space>`
 " Then select a compatible output format to apply and close
 " Result: 72 101 108 108 111
+```
+
+## 🧩 Custom formats
+
+Add your own units or conversions through `setup({ formats = { ... } })`.
+Each entry either `extend`s a built-in group or defines a new `key`/`kind`
+group. New formats appear in the selector, tab-completion and `:Convy`.
+
+### Add a unit to an existing group
+
+`length` is a `linear` group, so a new unit is just a `suffix` and a
+`factor` relative to the group's base (meters):
+
+```lua
+require("convy").setup({
+  formats = {
+    { extend = "length", formats = {
+      { name = "smoot", suffix = "smoot", factor = 1.7018 },
+    }},
+  },
+})
+-- :Convy smoot m -> 1smoot becomes 1.7018m
+```
+
+### Define a new group with custom conversions
+
+A `custom` group converts through a shared base: each format provides
+`decode(text) -> base` and `encode(base) -> text`. Conversion is
+`out.encode(in.decode(text))`, so N formats only need N function pairs.
+
+This example treats a uint32 as a Unix timestamp (epoch seconds) and
+converts between the raw integer, hex, and an ISO 8601 UTC date:
+
+```lua
+local function iso_to_epoch(text)
+  local y, mo, d, h, mi, s = text:match("(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+)")
+  if not y then return nil end
+  -- os.time uses local time; subtract the local UTC offset to get UTC epoch.
+  local utc_offset = os.time(os.date("!*t", 0))
+  return os.time({
+    year = tonumber(y), month = tonumber(mo), day = tonumber(d),
+    hour = tonumber(h), min = tonumber(mi), sec = tonumber(s), isdst = false,
+  }) - utc_offset
+end
+
+require("convy").setup({
+  formats = {
+    {
+      key = "epoch",
+      label = "Epoch Date",
+      kind = "custom",
+      formats = {
+        {
+          name = "unix",
+          decode = function(text) return tonumber(text) end,
+          encode = function(secs) return tostring(math.floor(secs)) end,
+        },
+        {
+          name = "hex32",
+          decode = function(text) return tonumber(text, 16) end,
+          encode = function(secs) return string.format("%08X", secs) end,
+        },
+        {
+          name = "iso",
+          display = "ISO date",
+          -- optional: makes `auto` recognise ISO dates
+          detect = function(text) return text:match("^%d%d%d%d%-%d%d%-%d%dT") ~= nil end,
+          decode = iso_to_epoch,
+          encode = function(secs) return os.date("!%Y-%m-%dT%H:%M:%SZ", secs) end,
+        },
+      },
+    },
+  },
+})
+-- :Convy unix iso     ->  1700000000 becomes 2023-11-14T22:13:20Z
+-- :Convy auto unix    ->  2023-11-14T22:13:20Z becomes 1700000000
 ```
 
 ## 🏆 Roadmap

--- a/README.md
+++ b/README.md
@@ -212,14 +212,3 @@ require("convy").setup({
 -- :Convy unix iso     ->  1700000000 becomes 2023-11-14T22:13:20Z
 -- :Convy auto unix    ->  2023-11-14T22:13:20Z becomes 1700000000
 ```
-
-## 🏆 Roadmap
-
-- [ ] Drop visual-mode flag for util.function that guesses if we executed Convy in visual mode
-- [x] Support for more formats
-  - [x] Colors (RGB, HSL, ...)
-  - [x] Sizes (px, mm, in, ...)
-  - [x] Temperatures (C, F, ...)
-- [x] Interactive UI for selecting input/output formats
-- [x] Tab completion for conversion formats
-- [x] Automatic format detection

--- a/lua/convy/converters.lua
+++ b/lua/convy/converters.lua
@@ -2,23 +2,13 @@ local M = {}
 
 local formats = require("convy.formats")
 
-local group_modules = {
-	angle = "convy.converters.linear",
-	area = "convy.converters.linear",
-	color = "convy.converters.color",
-	datarate = "convy.converters.linear",
-	datasize = "convy.converters.linear",
+-- Converter module per group kind.
+local kind_modules = {
+	linear = "convy.converters.linear",
 	encoding = "convy.converters.encoding",
-	energy = "convy.converters.linear",
-	frequency = "convy.converters.linear",
-	length = "convy.converters.linear",
-	mass = "convy.converters.linear",
-	power = "convy.converters.linear",
-	pressure = "convy.converters.linear",
-	speed = "convy.converters.linear",
+	color = "convy.converters.color",
 	temperature = "convy.converters.temperature",
-	time = "convy.converters.linear",
-	volume = "convy.converters.linear",
+	custom = "convy.converters.custom",
 }
 
 function M.convert(text, input_format, output_format)
@@ -44,9 +34,10 @@ function M.convert(text, input_format, output_format)
 		)
 	end
 
-	local module_path = group_modules[group]
+	local kind = formats.get_group_def(input_format).kind
+	local module_path = kind_modules[kind]
 	if not module_path then
-		error("No converter module for group: " .. tostring(group), 0)
+		error("No converter for kind: " .. tostring(kind), 0)
 	end
 
 	return require(module_path).convert(text, input_format, output_format)

--- a/lua/convy/converters/custom.lua
+++ b/lua/convy/converters/custom.lua
@@ -1,0 +1,18 @@
+local M = {}
+
+local formats = require("convy.formats")
+
+-- Convert via the group's shared base: out.encode(in.decode(text)).
+function M.convert(text, input_format, output_format)
+	local in_entry = formats.get_entry(input_format)
+	local out_entry = formats.get_entry(output_format)
+
+	local base = in_entry.decode(text)
+	if base == nil then
+		error("Could not decode " .. input_format .. " value from: " .. text, 0)
+	end
+
+	return out_entry.encode(base)
+end
+
+return M

--- a/lua/convy/formats.lua
+++ b/lua/convy/formats.lua
@@ -289,13 +289,73 @@ M.groups = {
 	},
 }
 
--- Lookups: name -> group, name -> entry.
+-- Lookups: name -> group, name -> entry. Rebuilt whenever groups change.
 local name_to_group = {}
 local name_to_entry = {}
-for _, group in ipairs(M.groups) do
-	for _, entry in ipairs(group.formats) do
-		name_to_group[entry.name] = group
-		name_to_entry[entry.name] = entry
+
+local function rebuild()
+	name_to_group = {}
+	name_to_entry = {}
+	for _, group in ipairs(M.groups) do
+		for _, entry in ipairs(group.formats) do
+			name_to_group[entry.name] = group
+			name_to_entry[entry.name] = entry
+		end
+	end
+end
+
+rebuild()
+
+-- Register a user-defined group, or extend a built-in one.
+--   { extend = "length", formats = { ... } }  -- append to an existing group
+--   { key = "epoch", label = ..., kind = ..., formats = { ... } }  -- new group
+function M.register_group(spec)
+	local target = spec
+	if spec.extend then
+		target = nil
+		for _, group in ipairs(M.groups) do
+			if group.key == spec.extend then
+				target = group
+				break
+			end
+		end
+		if not target then
+			error("convy: cannot extend unknown group '" .. spec.extend .. "'", 0)
+		end
+	else
+		if not spec.key or not spec.kind then
+			error("convy: a new group needs a 'key' and a 'kind'", 0)
+		end
+		if M.label(spec.key) then
+			error("convy: group key '" .. spec.key .. "' already exists", 0)
+		end
+	end
+
+	for _, entry in ipairs(spec.formats) do
+		if entry.name == "auto" then
+			error("convy: 'auto' is a reserved format name", 0)
+		end
+		if name_to_entry[entry.name] then
+			error("convy: format name '" .. entry.name .. "' already exists", 0)
+		end
+		if (spec.kind or (target and target.kind)) == "custom" and not (entry.decode and entry.encode) then
+			error("convy: custom format '" .. entry.name .. "' needs decode and encode functions", 0)
+		end
+		name_to_entry[entry.name] = entry -- claim the name so later specs see the collision
+	end
+
+	if spec.extend then
+		for _, entry in ipairs(spec.formats) do
+			table.insert(target.formats, entry)
+		end
+	else
+		table.insert(M.groups, spec)
+	end
+
+	rebuild()
+	local utils = require("convy.utils")
+	if utils.reset_detection then
+		utils.reset_detection()
 	end
 end
 

--- a/lua/convy/init.lua
+++ b/lua/convy/init.lua
@@ -15,7 +15,16 @@ M.config = {
 }
 
 function M.setup(opts)
-	M.config = vim.tbl_deep_extend("force", M.config, opts or {})
+	opts = opts or {}
+
+	local custom = opts.formats
+	opts.formats = nil
+
+	M.config = vim.tbl_deep_extend("force", M.config, opts)
+
+	for _, spec in ipairs(custom or {}) do
+		formats.register_group(spec)
+	end
 end
 
 function M.get_input_formats()
@@ -25,7 +34,6 @@ end
 function M.get_output_formats(input_format)
 	return formats.get_output_formats(input_format)
 end
-
 
 -- Capture the source text and its position from the current window.
 local function capture_origin(use_visual)

--- a/lua/convy/utils.lua
+++ b/lua/convy/utils.lua
@@ -139,16 +139,21 @@ function M.replace_text(start_pos, end_pos, new_text)
 	vim.api.nvim_buf_set_lines(0, start_line - 1, end_line, false, new_lines)
 end
 
--- Unit suffixes from the registry, longest first so ambiguous prefixes
--- (e.g. "ms"/"min" vs "m"/"s") resolve correctly. Built once.
+-- Detection data built from the registry: unit suffixes (longest first so
+-- "ms"/"min" beat "m"/"s") and custom-format detect() predicates.
 local cached_suffixes
-local function unit_suffixes()
-	if cached_suffixes then
-		return cached_suffixes
-	end
+local cached_detectors
 
+-- Invalidate caches after the registry changes (e.g. register_group).
+function M.reset_detection()
+	cached_suffixes = nil
+	cached_detectors = nil
+end
+
+local function build_detection()
 	local formats = require("convy.formats")
 	cached_suffixes = {}
+	cached_detectors = {}
 	for _, group in ipairs(formats.groups) do
 		if group.kind == "linear" then
 			for _, entry in ipairs(group.formats) do
@@ -158,13 +163,32 @@ local function unit_suffixes()
 			for _, entry in ipairs(group.formats) do
 				table.insert(cached_suffixes, { suffix = entry.letter, format = entry.name, degree = true })
 			end
+		else
+			for _, entry in ipairs(group.formats) do
+				if entry.detect then
+					table.insert(cached_detectors, entry)
+				end
+			end
 		end
 	end
 
 	table.sort(cached_suffixes, function(a, b)
 		return #a.suffix > #b.suffix
 	end)
+end
+
+local function unit_suffixes()
+	if not cached_suffixes then
+		build_detection()
+	end
 	return cached_suffixes
+end
+
+local function custom_detectors()
+	if not cached_detectors then
+		build_detection()
+	end
+	return cached_detectors
 end
 
 -- Auto-detect input format
@@ -173,7 +197,7 @@ function M.detect_format(text)
 	local clean = text:match("^%s*(.-)%s*$") or text
 	local no_spaces = text:gsub("%s", "")
 
-	-- ── Color formats ──────────────────────────────────────────────
+	-- Color formats ---------------------------------------------
 
 	if clean:match("^hsl%s*%(") then
 		return "hsl"
@@ -192,7 +216,14 @@ function M.detect_format(text)
 		return "tailwind"
 	end
 
-	-- ── Unit formats (longest suffix first, case-insensitive) ─────
+	-- User-defined custom formats -------------------------------
+	for _, entry in ipairs(custom_detectors()) do
+		if entry.detect(clean) then
+			return entry.name
+		end
+	end
+
+	-- Unit formats (longest suffix first, case-insensitive) -----
 	local function ends_with_ci(str, suffix)
 		return #str >= #suffix and str:sub(-#suffix):lower() == suffix:lower()
 	end
@@ -207,7 +238,7 @@ function M.detect_format(text)
 		end
 	end
 
-	-- ── Text encoding formats (original detection logic) ───────────
+	-- Text encoding formats (original detection logic) ----------
 
 	if no_spaces:match("^0b[01]+") then
 		return "bin"


### PR DESCRIPTION
## Custom format groups & conversions

Lets users define their own format groups and conversions from their Neovim
config, addressing the request [*"a single uint32 that encodes a
date"*](https://www.reddit.com/r/neovim/comments/1ttyrlx/comment/opuq10h/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button) - a conversion nobody else needs, but nice to have.

### New features

- **Extend a built-in group** with new units (e.g. add a `smoot` to `length`).
- **Define a new group** with arbitrary conversions via a shared base: each format provides `decode(text) -> base` and `encode(base) -> text`, so conversion is `out.encode(in.decode(text))` (N formats = N function pairs, any-to-any within the group).
- Optional per-format `detect(text)` so `auto` recognises custom inputs.

New formats appear in the selector, tab-completion and `:Convy`, just like built-ins.

```lua
require("convy").setup({
  formats = {
    -- add a unit to a built-in group
    { extend = "length", formats = {
      { name = "smoot", suffix = "smoot", factor = 1.7018 },
    }},
    -- a new group: treat a uint32 as a Unix timestamp
    { key = "epoch", label = "Epoch Date", kind = "custom", formats = {
      { name = "unix", decode = tonumber,
                       encode = function(s) return tostring(math.floor(s)) end },
      { name = "iso",  encode = function(s) return os.date("!%Y-%m-%dT%H:%M:%SZ", s) end,
                       decode = function(t) --[[ parse ISO -> epoch ]] end },
    }},
  },
})
```

### How it works

- `formats.register_group(spec)` appends a new group or extends an existing one,
  validating duplicate names/keys, the reserved `auto`, and (for `custom`)
  required `encode`/`decode`. Lookup caches are rebuilt on registration.
- Converters now dispatch by **group kind** (equivalent for built-ins, required
  for user-defined group keys). New `custom` converter does
  `out.encode(in.decode(text))`.
- `detect_format` consults custom `detect()` predicates; caches are invalidated
  when groups are registered.
- `setup` pulls `opts.formats` out before the config deep-merge (which would
  mangle the group arrays) and registers each.

### Docs

A new **Custom formats** section in the README with two copy-pasteable recipes
(length unit + the full epoch/date group with `unix`/`hex32`/`iso`).

## Try it out

Copy this to your config file:

```lua
local function iso_to_epoch(text)
	local y, mo, d, h, mi, s = text:match("(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+)")
	if not y then
		return nil
	end
	local utc_offset = os.time(os.date("!*t", 0))
	return os.time({
		year = tonumber(y),
		month = tonumber(mo),
		day = tonumber(d),
		hour = tonumber(h),
		min = tonumber(mi),
		sec = tonumber(s),
		isdst = false,
	}) - utc_offset
end

{
	"necrom4/convy.nvim",
	branch = "feature/custom-formats" -- PR branch
	cmd = { "Convy", "ConvySeparator" },
	opts = {
		formats = {
			{
				key = "epoch",
				label = "Epoch Date",
				kind = "custom",
				formats = {
					{
						name = "unix",
						decode = function(text)
							return tonumber(text)
						end,
						encode = function(secs)
							return tostring(math.floor(secs))
						end,
					},
					{
						name = "hex32",
						decode = function(text)
							return tonumber(text, 16)
						end,
						encode = function(secs)
							return string.format("%08X", secs)
						end,
					},
					{
						name = "iso",
						display = "ISO date",
						detect = function(text)
							return text:match("^%d%d%d%d%-%d%d%-%d%dT") ~= nil
						end,
						decode = iso_to_epoch,
						encode = function(secs)
							return os.date("!%Y-%m-%dT%H:%M:%SZ", secs)
						end,
					},
				},
			},
		},
	},
}
```